### PR TITLE
Deshabilitar access_log en nginx

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,6 +4,8 @@ server {
     root /var/www/html/public;
     index index.php index.html;
 
+    access_log off;
+
     # Increase max body size for file uploads
     client_max_body_size 100M;
 


### PR DESCRIPTION
Deshabilitamos access_log en NGINX para evitar un alto consumo de AWS Cloudwatch!