### PR TITLE
Cambiar max-age a 1 minuto para api/web-content-*

### DIFF
--- a/app/Http/Middleware/CacheHeadersMiddleware.php
+++ b/app/Http/Middleware/CacheHeadersMiddleware.php
@@ -76,9 +76,9 @@ class CacheHeadersMiddleware
             return 300; // 5 minutes for product listings
         }
 
-        // Web content - 1 hour
+        // Web content - 1 min
         if (str_starts_with($path, 'api/web-content-')) {
-            return 3600;
+            return 60;
         }
 
         // Static data - 2 hours


### PR DESCRIPTION
Cambiamos el max-age para los `/api/web-content-*` a un minuto, para evitar que no se vean los cambios hechos en el admin.